### PR TITLE
fix init bug：

### DIFF
--- a/init.py
+++ b/init.py
@@ -1,6 +1,6 @@
 import os
 
-targets = ['tmp/dv_input/dv', 'tmp/dv_input/client', 'tmp/dv_output']
+targets = ['tmp','tmp/dv_input','tmp/dv_input/dv', 'tmp/dv_input/client', 'tmp/dv_output']
 
 for target in targets:
     try:


### PR DESCRIPTION
在完全新的路径下初始化，会报错错误：
```
Traceback (most recent call last):
  File "init.py", line 7, in <module>
    os.mkdir(target)
FileNotFoundError: [Errno 2] No such file or directory: 'tmp/dv_input/dv'
```